### PR TITLE
GoReleaser: separate Darwin (CGO_ENABLED=1) and Linux (CGO_ENABLED=0)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,19 +38,12 @@ task:
 task:
   name: Release (Dry Run)
   only_if: $CIRRUS_TAG == ''
-  container:
-    image: golang:latest
-    memory: 8GB
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-runner:sequoia
   depends_on:
     - Lint
     - Tests
-  prepare_script:
-    - apt-get update
-    - apt-get install -y libx11-dev
-  install_script:
-    - echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
-    - apt-get update
-    - apt-get -y install goreleaser-pro
+  install_script: brew install go goreleaser/tap/goreleaser-pro
   release_script: goreleaser build --snapshot
   goreleaser_artifacts:
     path: "dist/**"
@@ -58,9 +51,8 @@ task:
 task:
   name: Release
   only_if: $CIRRUS_TAG != ''
-  container:
-    image: golang:latest
-    memory: 8GB
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-runner:sequoia
   depends_on:
     - Lint
     - Tests
@@ -68,11 +60,5 @@ task:
     GITHUB_TOKEN: ENCRYPTED[!98ace8259c6024da912c14d5a3c5c6aac186890a8d4819fad78f3e0c41a4e0cd3a2537dd6e91493952fb056fa434be7c!]
     FURY_TOKEN: ENCRYPTED[!97fe4497d9aca60a3d64904883b81e21f19706c6aedda625c97f62f67ec46b8efa74c55699956158bbf0a23726e7d9f6!]
     GORELEASER_KEY: ENCRYPTED[!9b80b6ef684ceaf40edd4c7af93014ee156c8aba7e6e5795f41c482729887b5c31f36b651491d790f1f668670888d9fd!]
-  prepare_script:
-    - apt-get update
-    - apt-get install -y libx11-dev
-  install_script:
-    - echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
-    - apt-get update
-    - apt-get -y install goreleaser-pro
+  install_script: brew install go goreleaser/tap/goreleaser-pro
   release_script: goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,14 +5,27 @@ before:
     - go mod download
 
 builds:
-  - main: cmd/main.go
+  - id: darwin
+    main: cmd/main.go
+    ldflags: >
+      -X github.com/cirruslabs/tart-guest-agent/internal/version.Version={{.Version}}
+      -X github.com/cirruslabs/tart-guest-agent/internal/version.Commit={{.ShortCommit}}
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+  - id: linux
+    main: cmd/main.go
     ldflags: >
       -X github.com/cirruslabs/tart-guest-agent/internal/version.Version={{.Version}}
       -X github.com/cirruslabs/tart-guest-agent/internal/version.Commit={{.ShortCommit}}
     env:
       - CGO_ENABLED=0
     goos:
-      - darwin
       - linux
     goarch:
       - amd64


### PR DESCRIPTION
1. Can't build binaries for Darwin with `CGO_ENABLED=1` on Linux

    * let's build on Darwin

3. Can't build binaries for Linux with `CGO_ENABLED=1` on Darwin

    * let's build using separate `CGO_ENABLED` values