### PR TITLE
Build universal binary instead of architecture dependent

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,7 +44,7 @@ task:
     - Lint
     - Tests
   install_script: brew install go goreleaser/tap/goreleaser-pro
-  release_script: goreleaser build --snapshot
+  release_script: goreleaser release --clean --snapshot
   goreleaser_artifacts:
     path: "dist/**"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Environment / workspace settings:
+.vscode/
+
+# Distribution / packaging:
+dist/
+vendor/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+---
+version: 2
 project_name: tart-guest-agent
 
 before:
@@ -7,44 +9,47 @@ before:
 builds:
   - id: darwin
     main: cmd/main.go
-    ldflags: >
+    flags: >-
+      -trimpath
+    ldflags: >-
+      -s -w
       -X github.com/cirruslabs/tart-guest-agent/internal/version.Version={{.Version}}
       -X github.com/cirruslabs/tart-guest-agent/internal/version.Commit={{.ShortCommit}}
     env:
       - CGO_ENABLED=1
-    goos:
-      - darwin
-    goarch:
-      - amd64
-      - arm64
+    targets:
+      - darwin_amd64
+      - darwin_arm64
 
   - id: linux
     main: cmd/main.go
-    ldflags: >
+    flags: >-
+      -trimpath
+    ldflags: >-
+      -s -w
       -X github.com/cirruslabs/tart-guest-agent/internal/version.Version={{.Version}}
       -X github.com/cirruslabs/tart-guest-agent/internal/version.Commit={{.ShortCommit}}
     env:
       - CGO_ENABLED=0
-    goos:
-      - linux
-    goarch:
-      - amd64
-      - arm64
+    targets:
+      - linux_amd64
+      - linux_arm64
+
+universal_binaries:
+  - replace: true
+    ids:
+      - darwin
 
 archives:
-  - id: binary
-    format: binary
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
-  - id: regular
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+  - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    formats:
+      - tar.gz
 
 release:
   prerelease: auto
 
 brews:
-  - name: tart-guest-agent
-    ids:
-      - binary
+  - name: "{{ .ProjectName }}"
     repository:
       owner: cirruslabs
       name: homebrew-cli
@@ -54,13 +59,14 @@ brews:
     skip_upload: auto
 
 nfpms:
-  - package_name: tart-guest-agent
+  - package_name: "{{ .ProjectName }}"
     vendor: Cirrus Labs, Inc.
     homepage: https://github.com/cirruslabs/tart-guest-agent
     maintainer: support@cirruslabs.org
     description: Guest agent for Tart VMs
     section: misc
     formats:
+      - apk
       - deb
       - rpm
 


### PR DESCRIPTION
Also tweaked some things:

- Added missing `.gitignore`
- Added some flags for removing DWARF debugging information, symbol table and all file system paths from the resulting executable
- Added building `apk` packages for Alpine Linux
- Removed regular binaries from artifacts, `tar.gz` is just enough

Similar pull requests: https://github.com/cirruslabs/tart/pull/995, https://github.com/cirruslabs/softnet/pull/104