### PR TITLE
tart-guest-agent --run-agent: make errors non-fatal

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,7 +67,9 @@ task:
   depends_on:
     - Lint
     - Tests
-  install_script: brew install go goreleaser/tap/goreleaser-pro
+  install_script:
+    - brew install go
+    - brew install --cask goreleaser/tap/goreleaser-pro
   release_script: goreleaser release --clean --snapshot
   goreleaser_artifacts:
     path: "dist/**"
@@ -84,5 +86,7 @@ task:
     GITHUB_TOKEN: ENCRYPTED[!98ace8259c6024da912c14d5a3c5c6aac186890a8d4819fad78f3e0c41a4e0cd3a2537dd6e91493952fb056fa434be7c!]
     FURY_TOKEN: ENCRYPTED[!97fe4497d9aca60a3d64904883b81e21f19706c6aedda625c97f62f67ec46b8efa74c55699956158bbf0a23726e7d9f6!]
     GORELEASER_KEY: ENCRYPTED[!9b80b6ef684ceaf40edd4c7af93014ee156c8aba7e6e5795f41c482729887b5c31f36b651491d790f1f668670888d9fd!]
-  install_script: brew install go goreleaser/tap/goreleaser-pro
+  install_script:
+    - brew install go
+    - brew install --cask goreleaser/tap/goreleaser-pro
   release_script: goreleaser

--- a/internal/spice/vdagent/vdagent.go
+++ b/internal/spice/vdagent/vdagent.go
@@ -198,6 +198,10 @@ func (agent *VDAgent) Run(ctx context.Context) error {
 	}
 }
 
+func (agent *VDAgent) Close() error {
+	return agent.serialPort.Close()
+}
+
 func (agent *VDAgent) processClipboardState(newClipboardState []byte) error {
 	if bytes.Equal(agent.lastClipboardState, newClipboardState) {
 		// Nothing changed since the last VD_AGENT_CLIPBOARD_GRAB from us


### PR DESCRIPTION
It's observed but still unclear why `vdagent` component sometimes catches a `EOF` error while running.

This results in a fatal termination and a non-functioning RPC service for some time, which is critical for Orchard: https://github.com/cirruslabs/orchard/pull/323.

Let's not treat these errors as fatal and just log them and continue running.